### PR TITLE
Remove window.document

### DIFF
--- a/namespace.php
+++ b/namespace.php
@@ -28,7 +28,6 @@ function get_window_object() {
 	$port = $port !== '80' && $port !== '443' ? (int) $port : '';
 	$query = $_SERVER['QUERY_STRING'];
 	return [
-		'document' => null,
 		'location' => [
 			'hash'     => '',
 			'host'     => $port ? $_SERVER['HTTP_HOST'] . ':' . $port : $_SERVER['HTTP_HOST'],


### PR DESCRIPTION
Currently we define `window.document = null` which causes problems (I think with later version of react) with sniffs like:

```
'undefined' === typeof window ||
'undefined' === typeof window.document ||
'undefined' === typeof window.document.createElement
```

It seems we're now better off not declaring `window.document` as `null` is more of a "present" value in VS. I don't think there's any reason to set `window.document = undefined` as I think that's the same as not declaring it.

This fixes SSR on https://engineering.hmn.md/ for example.